### PR TITLE
fix(install): strip leading v from semver tags and fall back to single-root discovery

### DIFF
--- a/src/Command/Install.php
+++ b/src/Command/Install.php
@@ -491,8 +491,19 @@ class Install implements Module, ModuleUsage
         // Move contents from extracted directory to destination
         $extractedDir = $tmpExtract . '/' . $archiveDirName;
         if (!is_dir($extractedDir)) {
-            @rmdir($tmpExtract);
-            return false;
+            // Fallback: the predicted directory name did not match what
+            // the archive actually contained. This can happen when the
+            // archive comes from a non-GitHub source whose naming rules
+            // differ, or when GitHub changes its naming convention in a
+            // way the predictor does not yet model. Look for any single
+            // top-level directory and use it. If the layout is not the
+            // expected single-root shape, give up rather than guess.
+            $discovered = $this->findSingleTopLevelDirectory($tmpExtract);
+            if ($discovered === null) {
+                @rmdir($tmpExtract);
+                return false;
+            }
+            $extractedDir = $discovered;
         }
 
         // Move all files from extracted directory to destination
@@ -513,6 +524,53 @@ class Install implements Module, ModuleUsage
         @rmdir($tmpExtract);
 
         return true;
+    }
+
+    /**
+     * Locate a single top-level directory inside an extracted archive.
+     *
+     * Used by {@see extractArchive()} as a fallback when the predicted
+     * archive-directory name does not exist. Returns the absolute path
+     * to the discovered directory, or `null` if the archive does not
+     * have the conventional single-root-directory shape (e.g. files at
+     * the top level, multiple top-level directories, or an empty
+     * archive).
+     *
+     * Pure function (filesystem-driven): does not modify the directory
+     * it inspects.
+     *
+     * @param string $tmpExtract Path to the directory the archive was
+     *                           extracted into.
+     * @return string|null Absolute path to the single top-level
+     *                    directory, or null when the shape is not
+     *                    single-root.
+     */
+    private function findSingleTopLevelDirectory(string $tmpExtract): ?string
+    {
+        $entries = scandir($tmpExtract);
+        if ($entries === false) {
+            return null;
+        }
+
+        $topLevelDirs = [];
+        foreach ($entries as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $path = $tmpExtract . '/' . $entry;
+            if (!is_dir($path)) {
+                // A file at the top level is incompatible with the
+                // single-root shape we expect from a GitHub archive.
+                return null;
+            }
+            $topLevelDirs[] = $path;
+        }
+
+        if (count($topLevelDirs) !== 1) {
+            return null;
+        }
+
+        return $topLevelDirs[0];
     }
 
     /**
@@ -644,7 +702,18 @@ class Install implements Module, ModuleUsage
      * Get directory name from extracted archive
      *
      * GitHub archives extract to: {repo}-{ref}/
-     * The ref is sanitized (e.g., "feat/name" becomes "feat-name")
+     *
+     * Two rules to mirror:
+     *
+     *  1. The ref is sanitized — slashes become dashes (so `feat/foo`
+     *     in the URL produces `bundle-feat-foo/` on disk).
+     *
+     *  2. A leading 'v' is stripped from semver-like tags. GitHub keeps
+     *     the 'v' in the download URL but drops it in the directory
+     *     name inside the archive: `v1.1.1RC1.zip` extracts to
+     *     `bundle-1.1.1RC1/`. The heuristic matches `^v\d` so that
+     *     tags like `vendor-branch` (which happen to start with 'v'
+     *     but are not semver tags) are NOT stripped. See issue #13.
      *
      * @param string $repo Repository name
      * @param string $version Version/ref downloaded
@@ -652,8 +721,12 @@ class Install implements Module, ModuleUsage
      */
     private function getArchiveDirectoryName(string $repo, string $version): string
     {
-        // GitHub sanitizes ref names: replaces / with -
         $sanitizedRef = str_replace('/', '-', $version);
+
+        if (preg_match('/^v\d/', $sanitizedRef) === 1) {
+            $sanitizedRef = substr($sanitizedRef, 1);
+        }
+
         return "{$repo}-{$sanitizedRef}";
     }
 

--- a/test/Command/InstallArchiveDirectoryNameTest.php
+++ b/test/Command/InstallArchiveDirectoryNameTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ */
+
+namespace Horde\Hordectl\Test\Command;
+
+use Horde\Hordectl\Command\Install;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+
+/**
+ * Unit tests for {@see Install}'s archive-name prediction and the
+ * defensive single-top-level-directory discovery used by extractArchive().
+ *
+ * Both methods exercised here are pure functions (`getArchiveDirectoryName`
+ * is purely arithmetic on strings; `findSingleTopLevelDirectory` reads but
+ * does not modify the filesystem). Tests reach them via Reflection so the
+ * Install command's constructor — which wires several services — does not
+ * have to be built.
+ *
+ * Pins the fix for issue #13: a `v`-prefixed semver tag like `v1.1.1RC1`
+ * downloads correctly but extracts into a directory whose name has the
+ * leading `v` stripped (`bundle-1.1.1RC1`). The predictor must mirror
+ * GitHub's rule, and the extraction must fall back to discovery when the
+ * predictor disagrees with reality.
+ */
+#[CoversClass(Install::class)]
+class InstallArchiveDirectoryNameTest extends TestCase
+{
+    private ReflectionMethod $getArchiveDirectoryName;
+    private ReflectionMethod $findSingleTopLevelDirectory;
+    private Install $instance;
+
+    /** Scratch directory created per-test for filesystem-touching cases. */
+    private ?string $tmpDir = null;
+
+    protected function setUp(): void
+    {
+        $ref = new ReflectionClass(Install::class);
+        $this->instance = $ref->newInstanceWithoutConstructor();
+
+        $this->getArchiveDirectoryName = $ref->getMethod('getArchiveDirectoryName');
+        $this->getArchiveDirectoryName->setAccessible(true);
+
+        $this->findSingleTopLevelDirectory = $ref->getMethod('findSingleTopLevelDirectory');
+        $this->findSingleTopLevelDirectory->setAccessible(true);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->tmpDir !== null && is_dir($this->tmpDir)) {
+            $this->recursiveRemove($this->tmpDir);
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // getArchiveDirectoryName — the prediction layer (issue #13)
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function testStripsLeadingVFromSemverTag(): void
+    {
+        // The bundle's v1.1.1RC1 tag is the exact case from issue #13.
+        self::assertSame(
+            'bundle-1.1.1RC1',
+            $this->getArchiveDirectoryName->invoke($this->instance, 'bundle', 'v1.1.1RC1'),
+        );
+    }
+
+    #[Test]
+    public function testStripsLeadingVFromOtherSemverShapes(): void
+    {
+        self::assertSame(
+            'bundle-2.0.0',
+            $this->getArchiveDirectoryName->invoke($this->instance, 'bundle', 'v2.0.0'),
+        );
+        self::assertSame(
+            'bundle-2.0.0-beta1',
+            $this->getArchiveDirectoryName->invoke($this->instance, 'bundle', 'v2.0.0-beta1'),
+        );
+        self::assertSame(
+            'bundle-10.5.0',
+            $this->getArchiveDirectoryName->invoke($this->instance, 'bundle', 'v10.5.0'),
+        );
+    }
+
+    #[Test]
+    public function testLeavesUnprefixedTagsUntouched(): void
+    {
+        // The bundle's pre-RC1 tag history was unprefixed (1.0.0..1.0.3).
+        // Those continue to work as before.
+        self::assertSame(
+            'bundle-1.0.3',
+            $this->getArchiveDirectoryName->invoke($this->instance, 'bundle', '1.0.3'),
+        );
+    }
+
+    #[Test]
+    public function testLeavesNonVersionVTagsUntouched(): void
+    {
+        // Tags that happen to start with 'v' but are not semver-like
+        // must NOT be stripped. GitHub does not strip them either.
+        self::assertSame(
+            'bundle-vendor',
+            $this->getArchiveDirectoryName->invoke($this->instance, 'bundle', 'vendor'),
+        );
+        self::assertSame(
+            'bundle-vfoo',
+            $this->getArchiveDirectoryName->invoke($this->instance, 'bundle', 'vfoo'),
+        );
+        self::assertSame(
+            'bundle-v-something',
+            $this->getArchiveDirectoryName->invoke($this->instance, 'bundle', 'v-something'),
+        );
+    }
+
+    #[Test]
+    public function testReplacesSlashWithDash(): void
+    {
+        // Branch names with slashes get sanitized: GitHub's archive URL
+        // for refs/heads/feat/foo extracts to bundle-feat-foo/.
+        self::assertSame(
+            'bundle-feat-foo',
+            $this->getArchiveDirectoryName->invoke($this->instance, 'bundle', 'feat/foo'),
+        );
+    }
+
+    #[Test]
+    public function testSlashSanitizationAndVStrippingCompose(): void
+    {
+        // A hypothetical v-prefixed branch name with a slash exercises
+        // both rules at once. (Unusual, but the regex applies AFTER
+        // slash replacement, so this is consistent.)
+        self::assertSame(
+            'bundle-1.0-rc',
+            $this->getArchiveDirectoryName->invoke($this->instance, 'bundle', 'v1.0/rc'),
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // findSingleTopLevelDirectory — the defensive discovery layer
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function testFindSingleTopLevelDirectoryReturnsSoleSubdir(): void
+    {
+        $tmp = $this->makeTmpDir();
+        mkdir($tmp . '/bundle-actually-1.2.3');
+
+        $result = $this->findSingleTopLevelDirectory->invoke($this->instance, $tmp);
+
+        self::assertSame($tmp . '/bundle-actually-1.2.3', $result);
+    }
+
+    #[Test]
+    public function testFindSingleTopLevelDirectoryReturnsNullForEmptyArchive(): void
+    {
+        $tmp = $this->makeTmpDir();
+
+        $result = $this->findSingleTopLevelDirectory->invoke($this->instance, $tmp);
+
+        self::assertNull($result);
+    }
+
+    #[Test]
+    public function testFindSingleTopLevelDirectoryReturnsNullForMultipleDirs(): void
+    {
+        // Two top-level directories is ambiguous; we refuse to guess.
+        $tmp = $this->makeTmpDir();
+        mkdir($tmp . '/a');
+        mkdir($tmp . '/b');
+
+        $result = $this->findSingleTopLevelDirectory->invoke($this->instance, $tmp);
+
+        self::assertNull($result);
+    }
+
+    #[Test]
+    public function testFindSingleTopLevelDirectoryReturnsNullForFilesAtTopLevel(): void
+    {
+        // A loose file at the top level breaks the single-root shape.
+        $tmp = $this->makeTmpDir();
+        mkdir($tmp . '/some-dir');
+        file_put_contents($tmp . '/stray.txt', 'noise');
+
+        $result = $this->findSingleTopLevelDirectory->invoke($this->instance, $tmp);
+
+        self::assertNull($result);
+    }
+
+    // ---------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------
+
+    private function makeTmpDir(): string
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/hordectl_install_test_' . uniqid('', true);
+        mkdir($this->tmpDir, 0o755, true);
+        return $this->tmpDir;
+    }
+
+    private function recursiveRemove(string $path): void
+    {
+        if (!is_dir($path)) {
+            @unlink($path);
+            return;
+        }
+        foreach (scandir($path) as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $this->recursiveRemove($path . '/' . $entry);
+        }
+        @rmdir($path);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #13.

`hordectl install` failed to find the extracted archive's top-level directory whenever the bundle tag was prefixed with `v` (e.g. `v1.1.1RC1`). GitHub keeps the `v` in the download URL but **strips it from the directory name inside the archive**: `v1.1.1RC1.zip` extracts to `bundle-1.1.1RC1/`, not `bundle-v1.1.1RC1/`. The bug surfaced with the bundle's `v1.1.1RC1` tag (the first `v`-prefixed release); earlier `1.0.x` tags worked because no asymmetry existed.

Two layers:

1. **Mirror GitHub's naming rule.** `getArchiveDirectoryName()` now strips a leading `v` from refs that match `^v\d` (i.e. semver-like). Refs that happen to start with `v` but are not version tags (`vendor`, `vfoo`, `v-special`) are left alone — GitHub doesn't strip them either.

2. **Discovery fallback.** When the predicted directory name is absent in the extracted archive, `extractArchive()` falls back to looking for a single top-level directory and uses it. Covers cases where GitHub changes a naming rule we don't yet model, or where the archive comes from a non-GitHub source whose conventions differ. The fallback refuses to guess when the archive is empty, has multiple top-level directories, or has files at the top level.

A new private helper `findSingleTopLevelDirectory()` keeps the fallback logic pure-function and unit-testable.

## Workaround for users on the released version

While waiting for the next hordectl release, the original-reporter command works if you pass the tag without the `v`:

```
hordectl install --install-dir=/var/www/test-horde --bundle-version=1.1.1RC1
```

GitHub resolves `archive/1.1.1RC1.zip` and `archive/v1.1.1RC1.zip` to the same content for the `v1.1.1RC1` tag, and the unprefixed form makes the predicted directory name match.