### PR TITLE
fix rename to manage cross-device link issues

### DIFF
--- a/src/Command/Install.php
+++ b/src/Command/Install.php
@@ -514,7 +514,7 @@ class Install implements Module, ModuleUsage
             }
             $source = $extractedDir . '/' . $file;
             $dest = $destinationDir . '/' . $file;
-            if (!rename($source, $dest)) {
+            if (!$this->xlink_rename($source, $dest)) {
                 return false;
             }
         }
@@ -525,6 +525,67 @@ class Install implements Module, ModuleUsage
 
         return true;
     }
+    /**
+     * replacement for rename because of cross link errors
+     *
+     * @param string $source source directory or filename
+     *
+     * @param string $target target directory or filename
+     */ 
+    private function xlink_rename(string $source, string $target): bool {
+    // 1. Try standard rename first (fastest if on the same layer)
+    if (@rename($source, $target)) {
+        return true;
+    }
+
+    // 2. Handle Directory Transfers Recursively
+    if (is_dir($source)) {
+        if (!is_dir($target)) {
+            mkdir($target, 0755, true);
+        }
+        
+        $dir = opendir($source);
+        if (!$dir) {
+            return false;
+        }
+
+        while (($file = readdir($dir)) !== false) {
+            if ($file === '.' || $file === '..') {
+                continue;
+            }
+            
+            $srcFile = $source . '/' . $file;
+            $tgtFile = $target . '/' . $file;
+            
+            // Recursively process nested directories and files
+            if (is_dir($srcFile)) {
+                if (!$this->xlink_rename($srcFile, $tgtFile)) {
+                    closedir($dir);
+                    return false;
+                }
+            } else {
+                if (!copy($srcFile, $tgtFile) || !unlink($srcFile)) {
+                    closedir($dir);
+                    return false;
+                }
+            }
+        }
+        closedir($dir);
+        
+        // At this point, all files and subfolders are guaranteed to be gone
+        return rmdir($source);
+    } 
+    
+    // 3. Handle Single File Transfers
+    if (is_file($source)) {
+        if (copy($source, $target)) {
+            return unlink($source);
+        }
+    }
+    
+    return false;
+}
+
 
     /**
      * Locate a single top-level directory inside an extracted archive.
@@ -751,7 +812,7 @@ class Install implements Module, ModuleUsage
             // Create temporary tar file
             $tmpFile = tempnam(sys_get_temp_dir(), 'horde_local_');
             $tarFile = $tmpFile . '.tar';
-            rename($tmpFile, $tarFile);
+            $this->xlink_rename($tmpFile, $tarFile);
 
             // Use git archive to export specific ref
             $cmd = sprintf(

--- a/src/Command/Install.php
+++ b/src/Command/Install.php
@@ -29,6 +29,7 @@ use Horde\Http\StreamFactory;
 use Horde\Injector\Injector;
 use Horde\Cli\Modular\Module;
 use Horde\Cli\Modular\ModuleUsage;
+use Horde\Composer\RecursiveCopy;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use RuntimeException;
@@ -506,18 +507,8 @@ class Install implements Module, ModuleUsage
             $extractedDir = $discovered;
         }
 
-        // Move all files from extracted directory to destination
-        $files = scandir($extractedDir);
-        foreach ($files as $file) {
-            if ($file === '.' || $file === '..') {
-                continue;
-            }
-            $source = $extractedDir . '/' . $file;
-            $dest = $destinationDir . '/' . $file;
-            if (!$this->xlink_rename($source, $dest)) {
-                return false;
-            }
-        }
+        $copy = new RecursiveCopy($extractedDir, $destinationDir);
+        $copy->copy();
 
         // Cleanup
         @rmdir($extractedDir);
@@ -525,66 +516,6 @@ class Install implements Module, ModuleUsage
 
         return true;
     }
-    /**
-     * replacement for rename because of cross link errors
-     *
-     * @param string $source source directory or filename
-     *
-     * @param string $target target directory or filename
-     */ 
-    private function xlink_rename(string $source, string $target): bool {
-    // 1. Try standard rename first (fastest if on the same layer)
-    if (@rename($source, $target)) {
-        return true;
-    }
-
-    // 2. Handle Directory Transfers Recursively
-    if (is_dir($source)) {
-        if (!is_dir($target)) {
-            mkdir($target, 0755, true);
-        }
-        
-        $dir = opendir($source);
-        if (!$dir) {
-            return false;
-        }
-
-        while (($file = readdir($dir)) !== false) {
-            if ($file === '.' || $file === '..') {
-                continue;
-            }
-            
-            $srcFile = $source . '/' . $file;
-            $tgtFile = $target . '/' . $file;
-            
-            // Recursively process nested directories and files
-            if (is_dir($srcFile)) {
-                if (!$this->xlink_rename($srcFile, $tgtFile)) {
-                    closedir($dir);
-                    return false;
-                }
-            } else {
-                if (!copy($srcFile, $tgtFile) || !unlink($srcFile)) {
-                    closedir($dir);
-                    return false;
-                }
-            }
-        }
-        closedir($dir);
-        
-        // At this point, all files and subfolders are guaranteed to be gone
-        return rmdir($source);
-    } 
-    
-    // 3. Handle Single File Transfers
-    if (is_file($source)) {
-        if (copy($source, $target)) {
-            return unlink($source);
-        }
-    }
-    
-    return false;
-}
 
 
     /**

--- a/src/Command/Install.php
+++ b/src/Command/Install.php
@@ -29,7 +29,6 @@ use Horde\Http\StreamFactory;
 use Horde\Injector\Injector;
 use Horde\Cli\Modular\Module;
 use Horde\Cli\Modular\ModuleUsage;
-use Horde\Composer\RecursiveCopy;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use RuntimeException;
@@ -507,16 +506,21 @@ class Install implements Module, ModuleUsage
             $extractedDir = $discovered;
         }
 
-        $copy = new RecursiveCopy($extractedDir, $destinationDir);
-        $copy->copy();
+        // Move contents into the destination. rename() is the fast
+        // path when both trees share a filesystem; it falls back to a
+        // recursive copy on EXDEV ("Invalid cross-device link"), which
+        // Docker overlay mounts and tmpfs /tmp reliably trigger.
+        if (!$this->moveDirectoryContents($extractedDir, $destinationDir)) {
+            return false;
+        }
 
-        // Cleanup
-        @rmdir($extractedDir);
+        // Cleanup. Anything the copy fallback left behind still needs
+        // to go; rename would already have emptied these dirs.
+        $this->recursiveDelete($extractedDir);
         @rmdir($tmpExtract);
 
         return true;
     }
-
 
     /**
      * Locate a single top-level directory inside an extracted archive.
@@ -563,6 +567,128 @@ class Install implements Module, ModuleUsage
         }
 
         return $topLevelDirs[0];
+    }
+
+    /**
+     * Move every entry from a source directory into a destination directory.
+     *
+     * Uses `rename()` as the fast path when the source and destination
+     * share a filesystem, and falls back to a recursive copy on
+     * `EXDEV` ("Invalid cross-device link"). The fallback matches how
+     * `mv(1)` handles the same situation: attempt rename, copy on
+     * EXDEV, delete the source afterwards.
+     *
+     * The fast path is worth preserving because a Horde bundle is
+     * thousands of files. Doing a full byte-copy on every install just
+     * to handle the minority case where /tmp lives on a different
+     * mount would slow down every install.
+     *
+     * TODO: factor out into a shared utility. `horde-installer-plugin`
+     * carries a similar `Horde\Composer\RecursiveCopy` helper that
+     * wants extracting into a small standalone package so both this
+     * command and the plugin can share it without hordectl pulling in
+     * a Composer plugin as a runtime dependency.
+     *
+     * @param string $sourceDir Directory whose entries should be moved.
+     * @param string $destDir   Directory to move them into.
+     *                          Must already exist.
+     * @return bool True on success, false if any entry could not be
+     *              moved or copied.
+     */
+    private function moveDirectoryContents(string $sourceDir, string $destDir): bool
+    {
+        $entries = scandir($sourceDir);
+        if ($entries === false) {
+            return false;
+        }
+        foreach ($entries as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $src = $sourceDir . '/' . $entry;
+            $dst = $destDir . '/' . $entry;
+
+            // Fast path: same-filesystem rename. Suppress the warning
+            // so the EXDEV fallback stays quiet on cross-device moves.
+            if (@rename($src, $dst)) {
+                continue;
+            }
+
+            // Fallback: recursive copy. The source is deleted in a
+            // single pass after all entries have been copied, so
+            // failures here abort before we start pruning /tmp.
+            if (!$this->recursiveCopy($src, $dst)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Recursively copy a file or directory.
+     *
+     * Regular files and symlinks are copied with `copy()` (which
+     * follows symlinks — good enough for extracted release archives,
+     * which do not carry meaningful symlinks). Directories are
+     * mirrored, preserving their permissions on a best-effort basis.
+     *
+     * TODO: factor out (see {@see moveDirectoryContents()}).
+     *
+     * @param string $source Source path (file or directory).
+     * @param string $dest   Destination path.
+     * @return bool True on success.
+     */
+    private function recursiveCopy(string $source, string $dest): bool
+    {
+        if (is_dir($source)) {
+            if (!is_dir($dest) && !mkdir($dest, 0o755, true) && !is_dir($dest)) {
+                return false;
+            }
+            $entries = scandir($source);
+            if ($entries === false) {
+                return false;
+            }
+            foreach ($entries as $entry) {
+                if ($entry === '.' || $entry === '..') {
+                    continue;
+                }
+                if (!$this->recursiveCopy($source . '/' . $entry, $dest . '/' . $entry)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        return copy($source, $dest);
+    }
+
+    /**
+     * Recursively delete a file or directory tree.
+     *
+     * Best-effort cleanup for the extract-then-move sequence in
+     * {@see extractArchive()}. Errors are swallowed because the goal
+     * is to avoid leaving debris under /tmp, not to guarantee the
+     * tree is gone.
+     *
+     * @param string $path Path to remove.
+     */
+    private function recursiveDelete(string $path): void
+    {
+        if (is_dir($path) && !is_link($path)) {
+            $entries = @scandir($path);
+            if ($entries !== false) {
+                foreach ($entries as $entry) {
+                    if ($entry === '.' || $entry === '..') {
+                        continue;
+                    }
+                    $this->recursiveDelete($path . '/' . $entry);
+                }
+            }
+            @rmdir($path);
+            return;
+        }
+        @unlink($path);
     }
 
     /**
@@ -740,10 +866,12 @@ class Install implements Module, ModuleUsage
             $output = [];
             $return = 0;
 
-            // Create temporary tar file
+            // Create temporary tar file. Both paths live under
+            // sys_get_temp_dir() so this rename is same-filesystem and
+            // safe from EXDEV.
             $tmpFile = tempnam(sys_get_temp_dir(), 'horde_local_');
             $tarFile = $tmpFile . '.tar';
-            $this->xlink_rename($tmpFile, $tarFile);
+            rename($tmpFile, $tarFile);
 
             // Use git archive to export specific ref
             $cmd = sprintf(


### PR DESCRIPTION
@ralflang,
When using hordectl without this patch, it created this error:
 rename(/tmp/horde_extract_6a44058e58ce8/bundle-1.1.1RC1/.github,/var/www/test-horde/.github): Invalid cross-device link

This change fixes for two scenarios:
 - Docker overlay's
 - /tmp setup up separately from wherever webserver gets extracted to (/var/www in my case)



