### PR TITLE
fix(webserver-config): scope nginx php handler per app for correct SCRIPT_FILENAME

### DIFF
--- a/src/Service/WebserverConfig/NginxEmitter.php
+++ b/src/Service/WebserverConfig/NginxEmitter.php
@@ -20,10 +20,16 @@ namespace Horde\Hordectl\Service\WebserverConfig;
  *   sites/<host>.conf    Per-host server blocks
  *   tls/<host>.conf      Operator-owned TLS knobs (sketch mode)
  *
- * Ordering matters in nginx location dispatch. The emitter puts
- * forbid blocks (specific paths) before the alias-based front-controller
- * fallback, and the fastcgi handler goes at server scope so it applies
- * across every included location block.
+ * Ordering matters in nginx location dispatch. Every app is wrapped
+ * in a single `^~` prefix location so it wins over any regex location
+ * at server scope. Inside it the forbid blocks (specific paths) come
+ * first, the php handler next, and the front-controller fallback last.
+ *
+ * The php handler is scoped PER APP rather than at server scope: an
+ * aliased subpath location needs SCRIPT_FILENAME derived from the
+ * alias ($request_filename), whereas a root-anchored app served from
+ * the server-level `root` uses $document_root$fastcgi_script_name. A
+ * single server-scope handler cannot satisfy both.
  */
 final class NginxEmitter
 {
@@ -40,7 +46,7 @@ final class NginxEmitter
         foreach ($map->apps as $app) {
             $entries[] = new EmitEntry(
                 $outputDir . '/horde-includes/apps/' . $app->id . '.conf',
-                $this->renderAppSnippet($app),
+                $this->renderAppSnippet($app, $phpHandlerSpec),
             );
         }
         $byHost = $this->groupByHost($map);
@@ -74,54 +80,81 @@ final class NginxEmitter
         return $out;
     }
 
-    private function renderAppSnippet(AppEntry $app): string
+    private function renderAppSnippet(AppEntry $app, string $phpHandlerSpec): string
     {
+        [$fastcgiDirective] = $this->render->phpHandler($phpHandlerSpec, 'nginx');
+        $rootAnchored = $app->isRootAnchored();
+        $pathPrefix = rtrim($app->pathPrefix(), '/');
+        $frontController = $this->render->frontControllerFor($app);
+        // For root-anchored apps the location covers `/`; for subpath
+        // apps the prefix path.
+        $locationMatch = $rootAnchored ? '/' : $pathPrefix . '/';
+        // SCRIPT_FILENAME has to reflect the on-disk path php-fpm should
+        // execute. For a root-anchored app served from the server-level
+        // `root`, $document_root$fastcgi_script_name is correct. For an
+        // aliased subpath location that expression points at the server
+        // root, NOT the app's fileroot, so php-fpm would fail to find
+        // the script. $request_filename honours the alias and resolves
+        // to <fileroot>/<script>.
+        $scriptFilename = $rootAnchored
+            ? '$document_root$fastcgi_script_name'
+            : '$request_filename';
+
         $header = $this->render->prerequisitesHeader('nginx', [
             'Prerequisites:',
             '  - nginx 1.18+',
-            '  - php-fpm reachable via the fastcgi_pass in the parent site block',
+            '  - php-fpm listening at the fastcgi_pass emitted below',
             '  - Included from a `server { }` block in sites/',
             'Limitations:',
-            '  - The location blocks below must appear in the order emitted:',
-            '    forbid blocks first, front-controller fallback last.',
+            '  - The nested location blocks must keep the order emitted:',
+            '    forbid blocks first, php handler next, front-controller last.',
+            '  - PATH_INFO is not split out; front controllers that route on',
+            '    PATH_INFO need an operator-supplied fastcgi_split_path_info.',
             '',
             'App: ' . $app->id,
             'Fileroot: ' . $app->fileroot,
             'Webroot: ' . $app->webroot,
-            $app->isRootAnchored()
+            $rootAnchored
                 ? 'Anchoring: root (parent server block sets `root` to fileroot; no alias here).'
-                : 'Anchoring: subpath (this snippet issues alias for ' . rtrim($app->pathPrefix(), '/') . '/).',
-            'Front controller: ' . $this->render->frontControllerFor($app),
+                : 'Anchoring: subpath (this snippet issues alias for ' . $pathPrefix . '/).',
+            'Front controller: ' . $frontController,
         ]);
-        $frontController = $this->render->frontControllerFor($app);
-        $pathPrefix = rtrim($app->pathPrefix(), '/');
-        // For root-anchored apps the location covers `/`; for subpath
-        // apps the prefix path.
-        $locationMatch = $app->isRootAnchored() ? '/' : $pathPrefix . '/';
 
+        // The whole app lives inside one `^~` prefix location. `^~`
+        // makes this prefix win over any regex location at server scope,
+        // and nesting the php handler here is what lets SCRIPT_FILENAME
+        // pick up the alias for subpath apps.
         $body = $header;
-        // Forbid blocks. For root-anchored apps the paths are top-level
-        // (`/lib/`); for subpath apps they carry the prefix.
+        $body .= sprintf("location ^~ %s {\n", $locationMatch);
+        // Root-anchored apps rely on the server-level `root` directive;
+        // subpath apps get their own `alias` here.
+        if (!$rootAnchored) {
+            $body .= "    alias " . $app->fileroot . "/;\n";
+        }
+        $body .= "\n";
+        // Forbid blocks first. For root-anchored apps the paths are
+        // top-level (`/lib/`); for subpath apps they carry the prefix.
         foreach ($this->render->forbiddenDirs as $sub) {
             if (!is_dir($app->fileroot . '/' . $sub)) {
                 continue;
             }
             $body .= sprintf(
-                "location ~ ^%s%s/ { return 403; }\n",
-                $app->isRootAnchored() ? '/' : $pathPrefix . '/',
+                "    location ~ ^%s%s/ { return 403; }\n",
+                $rootAnchored ? '/' : $pathPrefix . '/',
                 $sub,
             );
         }
-        $body .= "\n";
-        $body .= sprintf("location %s {\n", $locationMatch);
-        // Root-anchored apps rely on the server-level `root` directive;
-        // subpath apps get their own `alias` here.
-        if (!$app->isRootAnchored()) {
-            $body .= "    alias " . $app->fileroot . "/;\n";
-        }
-        // try_files fallback into the front controller. The target
-        // path uses the URL prefix so nginx routes correctly.
-        $tryTarget = $app->isRootAnchored()
+        // PHP handler, scoped to this app so SCRIPT_FILENAME is correct.
+        $body .= "    location ~ \\.php$ {\n";
+        $body .= "        include fastcgi_params;\n";
+        $body .= "        fastcgi_param SCRIPT_FILENAME " . $scriptFilename . ";\n";
+        $body .= "        fastcgi_param HTTP_AUTHORIZATION \$http_authorization;\n";
+        $body .= "        " . $fastcgiDirective . "\n";
+        $body .= "    }\n";
+        // try_files fallback into the front controller, last. The target
+        // path uses the URL prefix so the internal redirect re-enters
+        // this location and hits the php handler above.
+        $tryTarget = $rootAnchored
             ? '/' . $frontController
             : $pathPrefix . '/' . $frontController;
         $body .= "    try_files \$uri \$uri/ " . $tryTarget . "?\$args;\n";
@@ -134,7 +167,7 @@ final class NginxEmitter
      */
     private function renderSite(string $host, array $apps, string $phpHandlerSpec, string $prefix): string
     {
-        [$fastcgiDirective, $handlerLabel] = $this->render->phpHandler($phpHandlerSpec, 'nginx');
+        [, $handlerLabel] = $this->render->phpHandler($phpHandlerSpec, 'nginx');
         $anyTls = $this->render->anyTls($apps);
 
         // Identify the root-anchored app, if any. Only one is legal.
@@ -203,16 +236,11 @@ final class NginxEmitter
             $body .= "    # root /var/www/html;\n";
         }
         $body .= "\n";
+        // Each app snippet carries its own php handler (scoped to the
+        // app so SCRIPT_FILENAME honours the alias/root of that app).
         foreach ($apps as $app) {
             $body .= sprintf("    include %s/apps/%s.conf;\n", $includeBase, $app->id);
         }
-        $body .= "\n";
-        $body .= "    location ~ \\.php$ {\n";
-        $body .= "        include fastcgi_params;\n";
-        $body .= "        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n";
-        $body .= "        fastcgi_param HTTP_AUTHORIZATION \$http_authorization;\n";
-        $body .= "        " . $fastcgiDirective . "\n";
-        $body .= "    }\n";
         if ($anyTls) {
             $body .= sprintf("\n    include %s/tls/%s.conf;\n", $includeBase, $host);
         }

--- a/test/Command/WebserverConfig/WebserverConfigOptionsTest.php
+++ b/test/Command/WebserverConfig/WebserverConfigOptionsTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ */
+
+namespace Horde\Hordectl\Test\Command\WebserverConfig;
+
+use Horde\Hordectl\Command\WebserverConfig\WebserverConfigOptions;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the static tier-classification and flag-extraction helpers
+ * that feed the README provenance block.
+ */
+#[CoversClass(WebserverConfigOptions::class)]
+class WebserverConfigOptionsTest extends TestCase
+{
+    public function testClassifyTierDefaultsWhenBundlePathPresent(): void
+    {
+        $opts = (object) ['root_bundle_path' => '/var/www/horde'];
+        $this->assertSame('defaults', WebserverConfigOptions::classifyTier($opts));
+    }
+
+    public function testClassifyTierStdinWhenRegistryInDash(): void
+    {
+        $opts = (object) ['registry_in' => '-'];
+        $this->assertSame('stdin-yaml', WebserverConfigOptions::classifyTier($opts));
+    }
+
+    public function testClassifyTierBundlePathWinsOverStdin(): void
+    {
+        $opts = (object) ['root_bundle_path' => '/var/www/horde', 'registry_in' => '-'];
+        $this->assertSame('defaults', WebserverConfigOptions::classifyTier($opts));
+    }
+
+    public function testClassifyTierLiveRegistryByDefault(): void
+    {
+        $opts = (object) [];
+        $this->assertSame('live-registry', WebserverConfigOptions::classifyTier($opts));
+    }
+
+    public function testClassifyTierLiveRegistryWithDefaultUrlOverride(): void
+    {
+        // --default-url without --root-bundle-path stays tier 1 (the
+        // override layers on top of the live registry).
+        $opts = (object) ['default_url' => 'http://localhost'];
+        $this->assertSame('live-registry', WebserverConfigOptions::classifyTier($opts));
+    }
+
+    public function testExtractRelevantFlagsKeepsContentFlagsOnly(): void
+    {
+        $opts = (object) [
+            'default_url' => 'http://localhost',
+            'root_bundle_path' => '/var/www/horde',
+            'php_handler' => 'tcp:127.0.0.1:9000',
+            // These must be dropped: they do not change config content.
+            'force' => true,
+            'verbose' => true,
+            'output_dir' => '/tmp/out',
+        ];
+
+        $flags = WebserverConfigOptions::extractRelevantFlags($opts);
+
+        $this->assertSame(
+            [
+                '--default-url' => 'http://localhost',
+                '--root-bundle-path' => '/var/www/horde',
+                '--php-handler' => 'tcp:127.0.0.1:9000',
+            ],
+            $flags,
+        );
+    }
+
+    public function testExtractRelevantFlagsSkipsEmptyAndUnset(): void
+    {
+        $opts = (object) ['default_url' => '', 'app_webroots' => null];
+        $this->assertSame([], WebserverConfigOptions::extractRelevantFlags($opts));
+    }
+}

--- a/test/Service/WebserverConfig/AppMapBuilderTest.php
+++ b/test/Service/WebserverConfig/AppMapBuilderTest.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ */
+
+namespace Horde\Hordectl\Test\Service\WebserverConfig;
+
+use Horde\Hordectl\Service\WebserverConfig\AppEntry;
+use Horde\Hordectl\Service\WebserverConfig\AppMapBuilder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the tier-resolution and override logic in AppMapBuilder.
+ */
+#[CoversClass(AppMapBuilder::class)]
+class AppMapBuilderTest extends TestCase
+{
+    public function testFromDefaultsProducesRelativeWebroots(): void
+    {
+        $builder = new AppMapBuilder();
+        $map = $builder->fromDefaults('', '/nonexistent-bundle', '');
+
+        $this->assertTrue($map->ok);
+        $horde = $this->app($map->apps, 'horde');
+        $this->assertNotNull($horde);
+        $this->assertSame('/horde/', $horde->webroot);
+        $this->assertFalse($horde->isAbsolute());
+    }
+
+    public function testFromDefaultsAppliesInlineOverrides(): void
+    {
+        $builder = new AppMapBuilder();
+        $map = $builder->fromDefaults(
+            'http://localhost',
+            '/nonexistent-bundle',
+            'imp|https://webmail.example.org',
+        );
+
+        $this->assertTrue($map->ok);
+        $imp = $this->app($map->apps, 'imp');
+        $this->assertNotNull($imp);
+        $this->assertSame('https://webmail.example.org', $imp->webroot);
+        // A non-overridden app inherits --default-url.
+        $turba = $this->app($map->apps, 'turba');
+        $this->assertNotNull($turba);
+        $this->assertSame('http://localhost/turba/', $turba->webroot);
+    }
+
+    public function testApplyOverridesPromotesRelativeWebrootToAbsolute(): void
+    {
+        $builder = new AppMapBuilder();
+        $map = $builder->fromDefaults('', '/nonexistent-bundle', '');
+
+        $promoted = $builder->applyOverrides($map, '', 'http://localhost');
+
+        $this->assertTrue($promoted->ok);
+        $imp = $this->app($promoted->apps, 'imp');
+        $this->assertNotNull($imp);
+        $this->assertSame('http://localhost/imp/', $imp->webroot);
+    }
+
+    public function testApplyOverridesReplacesPerAppWebroot(): void
+    {
+        $builder = new AppMapBuilder();
+        $map = $builder->fromDefaults('', '/nonexistent-bundle', '');
+
+        $overridden = $builder->applyOverrides($map, 'imp|https://webmail.example.org', '');
+
+        $this->assertTrue($overridden->ok);
+        $imp = $this->app($overridden->apps, 'imp');
+        $this->assertNotNull($imp);
+        $this->assertSame('https://webmail.example.org', $imp->webroot);
+    }
+
+    public function testApplyOverridesDetectsWebrootCollision(): void
+    {
+        $builder = new AppMapBuilder();
+        $map = $builder->fromDefaults('', '/nonexistent-bundle', '');
+
+        // Point two different apps (distinct fileroots) at one webroot.
+        $collided = $builder->applyOverrides(
+            $map,
+            'imp|https://x.example.org/dup,turba|https://x.example.org/dup',
+            '',
+        );
+
+        $this->assertFalse($collided->ok);
+        $this->assertStringContainsString('different fileroots', $collided->error);
+    }
+
+    public function testApplyOverridesRecordsMalformedEntryAsWarning(): void
+    {
+        $builder = new AppMapBuilder();
+        $map = $builder->fromDefaults('', '/nonexistent-bundle', '');
+
+        $result = $builder->applyOverrides($map, 'this-has-no-separator', 'http://localhost');
+
+        $this->assertTrue($result->ok);
+        $this->assertNotEmpty($result->warnings);
+        $this->assertStringContainsString('malformed', $result->warnings[0]);
+    }
+
+    public function testFromStdinYamlEmptyFails(): void
+    {
+        $builder = new AppMapBuilder();
+        $map = $builder->fromStdinYaml('');
+
+        $this->assertFalse($map->ok);
+    }
+
+    public function testFromStdinYamlBareAppMap(): void
+    {
+        $builder = new AppMapBuilder();
+        $yaml = <<<YAML
+horde:
+    fileroot: /var/www/horde/web/horde
+    webroot: /horde
+imp:
+    fileroot: /var/www/horde/web/imp
+    webroot: /imp
+YAML;
+        $map = $builder->fromStdinYaml($yaml);
+
+        $this->assertTrue($map->ok);
+        $this->assertCount(2, $map->apps);
+        $horde = $this->app($map->apps, 'horde');
+        $this->assertNotNull($horde);
+        $this->assertSame('/horde', $horde->webroot);
+        $this->assertSame('/var/www/horde/web/horde', $horde->fileroot);
+    }
+
+    public function testFromStdinYamlEnvelopeShape(): void
+    {
+        $builder = new AppMapBuilder();
+        // The wrapped shape `hordectl query registry` emits.
+        $yaml = <<<YAML
+apps:
+    builtin:
+        resources:
+            registry:
+                items:
+                    default:
+                        horde:
+                            fileroot: /var/www/horde/web/horde
+                            webroot: /horde
+YAML;
+        $map = $builder->fromStdinYaml($yaml);
+
+        $this->assertTrue($map->ok);
+        $horde = $this->app($map->apps, 'horde');
+        $this->assertNotNull($horde);
+        $this->assertSame('/horde', $horde->webroot);
+    }
+
+    public function testDefaultHostPrefersHordeApp(): void
+    {
+        $builder = new AppMapBuilder();
+        $yaml = <<<YAML
+imp:
+    fileroot: /var/www/horde/web/imp
+    webroot: https://webmail.example.org/
+horde:
+    fileroot: /var/www/horde/web/horde
+    webroot: https://horde.example.org/
+YAML;
+        $map = $builder->fromStdinYaml($yaml);
+
+        $this->assertTrue($map->ok);
+        $this->assertSame('horde.example.org', $map->defaultHost);
+    }
+
+    /**
+     * @param list<AppEntry> $apps
+     */
+    private function app(array $apps, string $id): ?AppEntry
+    {
+        foreach ($apps as $app) {
+            if ($app->id === $id) {
+                return $app;
+            }
+        }
+        return null;
+    }
+}

--- a/test/Service/WebserverConfig/GenerationContextTest.php
+++ b/test/Service/WebserverConfig/GenerationContextTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ */
+
+namespace Horde\Hordectl\Test\Service\WebserverConfig;
+
+use Horde\Hordectl\Service\WebserverConfig\GenerationContext;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the reproducer command rendering in GenerationContext.
+ */
+#[CoversClass(GenerationContext::class)]
+class GenerationContextTest extends TestCase
+{
+    public function testReproducerRendersFlagsInOrder(): void
+    {
+        $context = new GenerationContext(
+            tier: 'defaults',
+            flavor: 'nginx',
+            flags: [
+                '--default-url' => 'http://localhost',
+                '--root-bundle-path' => '/var/www/horde',
+            ],
+        );
+
+        $this->assertSame(
+            'hordectl webserver-config nginx --default-url=http://localhost --root-bundle-path=/var/www/horde',
+            $context->reproducer(),
+        );
+    }
+
+    public function testReproducerRendersStoreTrueFlagWithoutValue(): void
+    {
+        $context = new GenerationContext(
+            tier: 'live-registry',
+            flavor: 'apache-vhost',
+            flags: ['--registry-in' => true],
+        );
+
+        $this->assertSame(
+            'hordectl webserver-config apache-vhost --registry-in',
+            $context->reproducer(),
+        );
+    }
+
+    public function testReproducerSkipsEmptyAndFalseFlags(): void
+    {
+        $context = new GenerationContext(
+            tier: 'live-registry',
+            flavor: 'nginx',
+            flags: [
+                '--default-url' => '',
+                '--force' => false,
+                '--php-handler' => 'tcp:127.0.0.1:9000',
+            ],
+        );
+
+        $this->assertSame(
+            'hordectl webserver-config nginx --php-handler=tcp:127.0.0.1:9000',
+            $context->reproducer(),
+        );
+    }
+
+    public function testReproducerShellQuotesValuesWithSpaces(): void
+    {
+        $context = new GenerationContext(
+            tier: 'defaults',
+            flavor: 'nginx',
+            flags: ['--app-webroots' => 'imp|http://x/a b'],
+        );
+
+        $this->assertSame(
+            "hordectl webserver-config nginx --app-webroots='imp|http://x/a b'",
+            $context->reproducer(),
+        );
+    }
+}

--- a/test/Service/WebserverConfig/NginxEmitterTest.php
+++ b/test/Service/WebserverConfig/NginxEmitterTest.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ */
+
+namespace Horde\Hordectl\Test\Service\WebserverConfig;
+
+use Horde\Hordectl\Service\WebserverConfig\AppEntry;
+use Horde\Hordectl\Service\WebserverConfig\EmitEntry;
+use Horde\Hordectl\Service\WebserverConfig\MapBuildResult;
+use Horde\Hordectl\Service\WebserverConfig\NginxEmitter;
+use Horde\Hordectl\Service\WebserverConfig\RenderHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the nginx flavor emitter, with emphasis on the
+ * SCRIPT_FILENAME / alias correctness that a plain server-scope php
+ * handler could not provide.
+ */
+#[CoversClass(NginxEmitter::class)]
+class NginxEmitterTest extends TestCase
+{
+    private string $tmpRoot = '';
+
+    private string $phpHandler = 'unix-socket:/run/php/php8.4-fpm.sock';
+
+    protected function setUp(): void
+    {
+        $this->tmpRoot = sys_get_temp_dir() . '/hordectl-nginx-test-' . bin2hex(random_bytes(6));
+        mkdir($this->tmpRoot, 0o755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->tmpRoot !== '' && is_dir($this->tmpRoot)) {
+            $this->rrmdir($this->tmpRoot);
+        }
+    }
+
+    public function testSubpathAppUsesRequestFilenameNotDocumentRoot(): void
+    {
+        $fileroot = $this->makeFileroot('imp', ['lib']);
+        $map = MapBuildResult::success(
+            [new AppEntry(id: 'imp', fileroot: $fileroot, webroot: '/imp/')],
+            '',
+            false,
+        );
+
+        $conf = $this->appConf($map, 'imp');
+
+        // The whole app is wrapped in a `^~` prefix location.
+        $this->assertStringContainsString('location ^~ /imp/ {', $conf);
+        // Subpath apps get their own alias.
+        $this->assertStringContainsString('alias ' . $fileroot . '/;', $conf);
+        // The php handler is nested and derives SCRIPT_FILENAME from the
+        // alias. This is the core regression guard.
+        $this->assertStringContainsString(
+            'fastcgi_param SCRIPT_FILENAME $request_filename;',
+            $conf,
+        );
+        $this->assertStringNotContainsString(
+            '$document_root$fastcgi_script_name',
+            $conf,
+        );
+        // fastcgi_pass is emitted per app.
+        $this->assertStringContainsString(
+            'fastcgi_pass unix:/run/php/php8.4-fpm.sock;',
+            $conf,
+        );
+        // Front-controller fallback keeps the URL prefix so the internal
+        // redirect re-enters this location.
+        $this->assertStringContainsString(
+            'try_files $uri $uri/ /imp/rampage.php?$args;',
+            $conf,
+        );
+        // Forbid block for the existing lib/ directory, prefixed and nested.
+        $this->assertStringContainsString(
+            'location ~ ^/imp/lib/ { return 403; }',
+            $conf,
+        );
+    }
+
+    public function testRootAnchoredAppUsesDocumentRoot(): void
+    {
+        $fileroot = $this->makeFileroot('horde', ['lib']);
+        $map = MapBuildResult::success(
+            [new AppEntry(id: 'horde', fileroot: $fileroot, webroot: '/')],
+            '',
+            false,
+        );
+
+        $conf = $this->appConf($map, 'horde');
+
+        $this->assertStringContainsString('location ^~ / {', $conf);
+        // Root-anchored apps rely on the server-level `root`; no alias
+        // directive is emitted (the header comment may mention the word).
+        $this->assertStringNotContainsString("\n    alias ", $conf);
+        $this->assertStringContainsString(
+            'fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;',
+            $conf,
+        );
+        $this->assertStringContainsString(
+            'try_files $uri $uri/ /rampage.php?$args;',
+            $conf,
+        );
+        $this->assertStringContainsString(
+            'location ~ ^/lib/ { return 403; }',
+            $conf,
+        );
+    }
+
+    public function testSiteBlockNoLongerCarriesServerScopePhpHandler(): void
+    {
+        $fileroot = $this->makeFileroot('horde', []);
+        $map = MapBuildResult::success(
+            [new AppEntry(id: 'horde', fileroot: $fileroot, webroot: '/')],
+            'horde.example.org',
+            false,
+        );
+
+        $site = $this->siteConf($map);
+
+        // php-fpm handling now lives in the per-app snippet only. The
+        // site block just includes the app confs.
+        $this->assertStringNotContainsString('fastcgi_pass', $site);
+        $this->assertStringContainsString(
+            'include /etc/nginx/horde-includes/apps/horde.conf;',
+            $site,
+        );
+    }
+
+    public function testAppSnippetOmitsForbidBlockForAbsentDir(): void
+    {
+        // No subdirectories created: forbid blocks must not be emitted
+        // for directories that do not exist on disk.
+        $fileroot = $this->makeFileroot('nag', []);
+        $map = MapBuildResult::success(
+            [new AppEntry(id: 'nag', fileroot: $fileroot, webroot: '/nag/')],
+            '',
+            false,
+        );
+
+        $conf = $this->appConf($map, 'nag');
+
+        $this->assertStringNotContainsString('return 403', $conf);
+    }
+
+    private function appConf(MapBuildResult $map, string $appId): string
+    {
+        $emitter = new NginxEmitter(new RenderHelper());
+        $entries = $emitter->emit($map, $this->tmpRoot . '/out', $this->phpHandler, '/etc/nginx');
+        return $this->contentFor($entries, '/horde-includes/apps/' . $appId . '.conf');
+    }
+
+    private function siteConf(MapBuildResult $map): string
+    {
+        $emitter = new NginxEmitter(new RenderHelper());
+        $entries = $emitter->emit($map, $this->tmpRoot . '/out', $this->phpHandler, '/etc/nginx');
+        return $this->contentFor($entries, '/sites/');
+    }
+
+    /**
+     * @param list<EmitEntry> $entries
+     */
+    private function contentFor(array $entries, string $pathSuffix): string
+    {
+        foreach ($entries as $entry) {
+            if (str_contains($entry->path, $pathSuffix)) {
+                return $entry->content;
+            }
+        }
+        $this->fail('No emitted entry matched ' . $pathSuffix);
+    }
+
+    /**
+     * @param list<string> $subdirs
+     */
+    private function makeFileroot(string $id, array $subdirs): string
+    {
+        $fileroot = $this->tmpRoot . '/web/' . $id;
+        mkdir($fileroot, 0o755, true);
+        file_put_contents($fileroot . '/rampage.php', "<?php\n");
+        foreach ($subdirs as $sub) {
+            mkdir($fileroot . '/' . $sub, 0o755, true);
+        }
+        return $fileroot;
+    }
+
+    private function rrmdir(string $dir): void
+    {
+        $items = scandir($dir) ?: [];
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            is_dir($path) ? $this->rrmdir($path) : unlink($path);
+        }
+        rmdir($dir);
+    }
+}


### PR DESCRIPTION
## Summary
- Fix nginx subpath apps being unservable: the per-app PHP handler now computes `SCRIPT_FILENAME` correctly for aliased locations.
- Add unit-test coverage for the `WebserverConfig` services introduced in #17.

## Motivation
#17 emitted a single server-scope `location ~ \.php$` using
`SCRIPT_FILENAME $document_root$fastcgi_script_name`. For an aliased
subpath app (e.g. `/imp/`) `$document_root` points at the server root,
not the app fileroot, so php-fpm receives a wrong path and cannot run the
front controller. With no root-anchored app there is no `root` directive
at all, leaving every subpath app unservable. Apache was unaffected; CI
only served the Apache flavor, so this went uncaught.

## Changes
- `NginxEmitter`: wrap each app in a `^~` prefix location; nest the PHP
  handler per app with `$document_root$fastcgi_script_name` (root-anchored)
  or `$request_filename` (subpath, honours the alias). Forbid blocks and
  the `try_files` fallback move inside the same location; the redundant
  server-scope handler is removed. Banner documents the PATH_INFO caveat.
- Tests: `NginxEmitterTest`, `AppMapBuilderTest`, `GenerationContextTest`,
  `WebserverConfigOptionsTest`.

## Test plan
- [x] `vendor/bin/phpunit` full suite green (195 tests)
- [x] New tests assert `$request_filename` for subpath, `$document_root`
      for root-anchored, nested forbid blocks, and no server-scope handler
- [ ] Manual: generate an nginx config for a subpath app and confirm
      php-fpm serves the front controller
